### PR TITLE
The package support Guzzle 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.4",
         "caseyamcl/guzzle_retry_middleware": "2.6.1",
-        "guzzlehttp/guzzle": "7.2.0"
+        "guzzlehttp/guzzle": "^7.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",


### PR DESCRIPTION
By default in Laravel 8 (The most used php framework) Guzzle 7.3 is installed.
There are no breacking change between Guzzle 7.2 and 7.3, so your package is working on guzzle 7.3 and will work on Laravel 8.