### PR TITLE
Add return value declaration to jsonSerialize()

### DIFF
--- a/lib/Model/AccountInfo.php
+++ b/lib/Model/AccountInfo.php
@@ -15,7 +15,7 @@ class AccountInfo implements \JsonSerializable
         $this->remainingCredit = isset($response->remainingCredit) ?  $response->remainingCredit : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'username' => $this->username,

--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -41,7 +41,7 @@ class Address implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/AuditDiff.php
+++ b/lib/Model/AuditDiff.php
@@ -17,7 +17,7 @@ class AuditDiff implements \JsonSerializable
         $this->new = isset($aDiff->new) ? $aDiff->new : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'action' => $this->action,

--- a/lib/Model/AuditLog.php
+++ b/lib/Model/AuditLog.php
@@ -29,7 +29,7 @@ class AuditLog implements \JsonSerializable
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/Check.php
+++ b/lib/Model/Check.php
@@ -38,7 +38,7 @@ class Check implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/CheckOptions.php
+++ b/lib/Model/CheckOptions.php
@@ -9,7 +9,7 @@ class ScreeningListsScope implements \JsonSerializable
     public string $mode;
     public iterable $lists;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'mode' => $this->mode,
@@ -29,7 +29,7 @@ class CheckOptions implements \JsonSerializable
     public ?int $minimumPermittedAge;
     public ?bool $clientDataValidation;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'screeningListsScope' => $this->screeningListsScope,

--- a/lib/Model/Client.php
+++ b/lib/Model/Client.php
@@ -44,7 +44,7 @@ class Client implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/CompanyDetails.php
+++ b/lib/Model/CompanyDetails.php
@@ -21,7 +21,7 @@ class CompanyDetails implements \JsonSerializable
         $this->incorporationType = isset($response->incorporationType) ? $response->incorporationType : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'name' => $this->name,

--- a/lib/Model/ComplyCubeCollection.php
+++ b/lib/Model/ComplyCubeCollection.php
@@ -11,6 +11,7 @@ class ComplyCubeCollection implements \Iterator
     public $pages;
     public $pageSize;
     public $totalSize;
+    public $totalItems;
     private $position = 0;
 
     public function __construct(string $model, \stdClass $apiResponse)

--- a/lib/Model/ComplyCubeCollection.php
+++ b/lib/Model/ComplyCubeCollection.php
@@ -24,27 +24,27 @@ class ComplyCubeCollection implements \Iterator
         $this->totalItems = $apiResponse->totalItems;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->items[$this->position];
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->items[$this->position]);
     }

--- a/lib/Model/Document.php
+++ b/lib/Model/Document.php
@@ -25,7 +25,7 @@ class Document implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/Event.php
+++ b/lib/Model/Event.php
@@ -19,7 +19,7 @@ class Event implements \JsonSerializable
         $this->createdAt = isset($response->createdAt) ? $response->createdAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/FlowSession.php
+++ b/lib/Model/FlowSession.php
@@ -27,7 +27,7 @@ class FlowSession implements \JsonSerializable
         $this->redirectUrl = isset($response->redirectUrl) ?  $response->redirectUrl : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'clientId' => $this->clientId,

--- a/lib/Model/Image.php
+++ b/lib/Model/Image.php
@@ -33,7 +33,7 @@ class Image implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/LiveVideo.php
+++ b/lib/Model/LiveVideo.php
@@ -23,7 +23,7 @@ class LiveVideo implements \JsonSerializable
         $this->updatedAt = isset($response->updatedAt) ? $response->updatedAt : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/PersonDetails.php
+++ b/lib/Model/PersonDetails.php
@@ -32,7 +32,7 @@ class PersonDetails implements \JsonSerializable
         $this->taxIdentificationNumber = isset($response->taxIdentificationNumber) ? $response->taxIdentificationNumber : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'firstName' => $this->firstName,

--- a/lib/Model/Report.php
+++ b/lib/Model/Report.php
@@ -15,7 +15,7 @@ class Report implements \JsonSerializable
         $this->data = $response->data;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'contentType' => $this->contentType,

--- a/lib/Model/RiskProfile.php
+++ b/lib/Model/RiskProfile.php
@@ -21,7 +21,7 @@ class RiskProfile implements \JsonSerializable
         $this->watchlistRisk = new WatchlistRisk($response->watchlistRisk);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'overall' => $this->overall,
@@ -48,7 +48,7 @@ class CountryRisk implements \JsonSerializable
         $this->breakdown = isset($response->breakdown) ? $response->breakdown : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'risk' => $this->risk,
@@ -69,7 +69,7 @@ class PoliticalExposureRisk implements \JsonSerializable
         $this->checkId = isset($response->checkId) ? $response->checkId : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'risk' => $this->risk,
@@ -93,7 +93,7 @@ class OccupationRisk implements \JsonSerializable
         $this->occupationTitle = isset($response->occupationTitle) ? $response->occupationTitle : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'risk' => $this->risk,
@@ -115,7 +115,7 @@ class WatchlistRisk implements \JsonSerializable
         $this->checkId = isset($response->checkId) ? $response->checkId : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'risk' => $this->risk,

--- a/lib/Model/TeamMember.php
+++ b/lib/Model/TeamMember.php
@@ -19,7 +19,7 @@ class TeamMember implements \JsonSerializable
         $this->createdAt = $response->createdAt;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -13,7 +13,7 @@ class Token implements \JsonSerializable
         $this->token = $response->token;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'token' => $this->token

--- a/lib/Model/Validation.php
+++ b/lib/Model/Validation.php
@@ -15,7 +15,7 @@ class Validation implements \JsonSerializable
         $this->outcome = $outcome;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'outcome' => $this->outcome,

--- a/lib/Model/Webhook.php
+++ b/lib/Model/Webhook.php
@@ -23,7 +23,7 @@ class Webhook implements \JsonSerializable
         $this->enabled = isset($response->enabled) ? $response->enabled : null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             'id' => $this->id,


### PR DESCRIPTION
To prevent a deprecation warning in modern PHP 8.x

Deprecated: Return type of ComplyCube\Model\XXX::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice