### PR TITLE
Fix return type to prevent deprecation warnings in PHP 8+

### DIFF
--- a/lib/Model/ComplyCubeCollection.php
+++ b/lib/Model/ComplyCubeCollection.php
@@ -49,7 +49,7 @@ class ComplyCubeCollection extends Model implements Iterator
         $this->rewind();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(
             parent::jsonSerialize(),
@@ -63,12 +63,12 @@ class ComplyCubeCollection extends Model implements Iterator
         $this->position = 0;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->items[$this->position];
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }

--- a/lib/Model/Model.php
+++ b/lib/Model/Model.php
@@ -69,7 +69,7 @@ abstract class Model implements JsonSerializable
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(
             array_map(function ($value) {


### PR DESCRIPTION
Deprecation warnings received (and marked by for instance PHPStan):

Deprecated: Return type of ComplyCube\Model\Model::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Deprecated: Return type of ComplyCube\Model\ComplyCubeCollection::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Deprecated: Return type of ComplyCube\Model\ComplyCubeCollection::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Deprecated: Return type of ComplyCube\Model\ComplyCubeCollection::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice